### PR TITLE
[WIP] Provide file compress and filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ export GO111MODULE=on
 operator-sdk generate k8s # if changes made to *_types.go
 go mod vendor
 operator-sdk build quay.io/$USER/must-gather-operator:v0.0.1
-sed -i "s|REPLACE_IMAGE|quay.io/$USER/must-gather-operator:v0.0.1|g" deploy/operator.yaml
+sed -i "s|REPLACE_IMAGE|quay.io/$USER/must-gather-operator:v0.0.1|g" deploy/06-operator.yaml
 docker push quay.io/$USER/must-gather-operator:v0.0.1
 ```
 

--- a/deploy/06-operator.yaml
+++ b/deploy/06-operator.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: must-gather-operator
           # Replace this with the built image name
-          image: quay.io/masayag/must-gather-operator:v0.0.1
+          image: REPLACE_IMAGE
           command:
           - must-gather-operator
           imagePullPolicy: Always

--- a/pkg/controller/mustgatherreport/mustgatherreport_controller.go
+++ b/pkg/controller/mustgatherreport/mustgatherreport_controller.go
@@ -361,12 +361,35 @@ func (r *ReconcileMustGatherReport) newPod(image string, cr *mustgatherv1alpha1.
 						},
 					},
 				},
-			},
-			Containers: []corev1.Container{
 				{
 					Name:    "copy",
 					Image:   image,
 					Command: []string{"/bin/bash", "-c", "trap : TERM INT; sleep infinity & wait"},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "must-gather-output",
+							MountPath: path.Clean(SourceDir),
+							ReadOnly:  false,
+						},
+					},
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:    "compress",
+					Image:   "quay.io/pkliczewski/fileops",
+					Command: []string{"./out/fileops"},
+					Env: []corev1.EnvVar{
+						{
+							Name:  "MINUTES",
+							Value: "5",
+						},
+						// TODO: we need to use one or the other
+						// {
+						// 	Name:  "LINES",
+						// 	Value: "100",
+						// },
+					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "must-gather-output",


### PR DESCRIPTION
We add last step to prepare files to be exposed by nginx. This functionality
uses [fileops](https://github.com/pkliczewski/fileops) repo. With next step we should move `compress` container to initcontainers and use nginx as a container.